### PR TITLE
fix: 각 API 엔드 포인트의 접근 권한 변경

### DIFF
--- a/src/main/java/com/solutio/api/domain/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/solutio/api/domain/applicant/controller/ApplicantController.java
@@ -95,7 +95,8 @@ public class ApplicantController {
         return ApiResponse.success(Status.OK.getCode(), Status.OK.getMessage(), response);
     }
 
-    @Operation(summary = "[Anonymous] 합격 여부 조회", description = "ROLE_ANONYMOUS 이상의 권한이 필요함")
+    @Operation(summary = "[Guest] 합격 여부 조회", description = "ROLE_GUEST 이상의 권한이 필요함")
+    @PreAuthorize("hasRole('GUEST')")
     @GetMapping("/my")
     public ApiResponse<?> checkApplicantPass() {
         ApplicantPassResponseDto response = applicantService.checkPassStatus();

--- a/src/main/java/com/solutio/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/solutio/api/global/config/SecurityConfig.java
@@ -40,7 +40,6 @@ public class SecurityConfig {
     };
 
     private static final String[] ALLOWED_ALL_API_ENDPOINTS_GET = {
-        "/api/v1/applicants/my",
         "/api/v1/recruitments",
     };
 


### PR DESCRIPTION
## 요약
- #19  
- 기존에 모두 PERMIT_ALL에 넣었던 api 엔드 포인트를 GET, POST로 나누어 상세하게 분류하였습니다.

## 변경 사항
- 기존에 모두 PERMIT_ALL에 넣었던 api 엔드 포인트를 GET, POST로 나누어 상세 분류
- 자신의 합격 여부 조회 API권한을 ROLE_ANONYMOUS에서 ROLE_GUEST로 상향

## 스크린 샷
[Guest권한 이상부터로 상향된 API의 스크린샷]
<img width="1475" height="252" alt="image" src="https://github.com/user-attachments/assets/5d237df9-748e-4722-977a-e528870a8657" />