### PR TITLE
refactor/#34: 비밀번호 검증 제약 조건 완화 및 Member Enum 매핑 수정

### DIFF
--- a/src/main/java/com/solutio/api/domain/applicant/dto/request/ApplicantCreateUpdateRequestDto.java
+++ b/src/main/java/com/solutio/api/domain/applicant/dto/request/ApplicantCreateUpdateRequestDto.java
@@ -27,11 +27,7 @@ public class ApplicantCreateUpdateRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해야 합니다.")
-    @Size(min = 8, max = 12, message = "비밀번호는 8~12자여야 합니다.")
-    @Pattern(
-        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,12}$",
-        message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."
-    )
+    @Size(min = 8, max = 16, message = "비밀번호는 8~16자여야 합니다.")
     private String password;
 
     @NotBlank(message = "소속 학과를 입력해야 합니다.")

--- a/src/main/java/com/solutio/api/domain/member/domain/Member.java
+++ b/src/main/java/com/solutio/api/domain/member/domain/Member.java
@@ -57,6 +57,7 @@ public class Member extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
     private ClassLevel classLevel;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 요약

- Close #34 
- 지원자 신청/수정 DTO 비밀번호 검증 제약 조건 완화 및 Member 엔티티 ClassLevel Enum 매핑 수정

## 변경 사항
  - ApplicantCreateUpdateRequestDto 내 비밀번호 문자 조합(영문/숫자/특수문자) 정규식 검증 제거 및 길이 제한(8~16자) 조정
  - Member 엔티티의 classLevel 필드에 누락된 @Enumerated(EnumType.STRING) 어노테이션 추가