### PR TITLE
fix: wget을 쓰지 않는 방식으로 헬스체크 개선

### DIFF
--- a/docker/backend/docker-compose.yml
+++ b/docker/backend/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: unless-stopped
     env_file: .env
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:${SERVER_PORT}/actuator/health"]
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/${SERVER_PORT:-8080} && echo -e \"GET /actuator/health HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3 && cat <&3 | grep -q \"UP\"'"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## 요약

- Closes #48
- 해당 PR에 대한 요약을 작성해주세요.

## 변경 사항

 - `docker/backend/docker-compose.yml` 백엔드 서비스의 `healthcheck.test` 구문 수정
 - `wget` 기반 헬스체크 명령어를 `/dev/tcp` 소켓 기반의 Bash 헬스체크 스크립트로 변경