### PR TITLE
refactor: Applicant PassStatus Enum 도입 및 ClassLevel UNASSIGNED 추가

### DIFF
--- a/src/main/java/com/solutio/api/domain/applicant/domain/Applicant.java
+++ b/src/main/java/com/solutio/api/domain/applicant/domain/Applicant.java
@@ -62,8 +62,9 @@ public class Applicant extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private ClassLevel classLevel;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean isApprove;
+    private PassStatus passStatus;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -105,21 +106,25 @@ public class Applicant extends BaseEntity implements UserDetails {
                 bojId,
                 mainLanguage,
                 applyReason,
-                null,
-                false
+                ClassLevel.UNASSIGNED,
+                PassStatus.PENDING
         );
     }
 
     public void approve() {
-        this.isApprove = true;
+        this.passStatus = PassStatus.APPROVED;
     }
 
     public void reject() {
-        this.isApprove = false;
+        this.passStatus = PassStatus.REJECTED;
+    }
+
+    public boolean isApproved() {
+        return this.passStatus == PassStatus.APPROVED;
     }
 
     public void updateClassLevel(ApplicantUpdateClassLevelRequestDto requestDto) {
-        this.classLevel = requestDto.getClassLevel();
+        this.classLevel = requestDto.getClassLevel() == null ? ClassLevel.UNASSIGNED : requestDto.getClassLevel();
     }
 
     public void updateMyInfo(MemberUpdateRequestDto requestDto) {

--- a/src/main/java/com/solutio/api/domain/applicant/domain/PassStatus.java
+++ b/src/main/java/com/solutio/api/domain/applicant/domain/PassStatus.java
@@ -1,0 +1,15 @@
+package com.solutio.api.domain.applicant.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PassStatus {
+    PENDING("PENDING", "미정"),
+    APPROVED("APPROVED", "합격"),
+    REJECTED("REJECTED", "불합격");
+
+    private final String key;
+    private final String description;
+}

--- a/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantDetailResponseDto.java
+++ b/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.solutio.api.domain.applicant.dto.response;
 
 import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
 import com.solutio.api.domain.member.domain.MainLanguage;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +19,7 @@ public class ApplicantDetailResponseDto {
     private final String bojId;
     private final MainLanguage mainLanguage;
     private final String applyReason;
-    private final Boolean isApprove;
+    private final PassStatus passStatus;
     private final String classLevel;
     private final LocalDateTime createdAt;
 
@@ -32,8 +33,8 @@ public class ApplicantDetailResponseDto {
                 .bojId(applicant.getBojId())
                 .mainLanguage(applicant.getMainLanguage())
                 .applyReason(applicant.getApplyReason())
-                .isApprove(applicant.getIsApprove())
-                .classLevel(applicant.getClassLevel() == null ? null: applicant.getClassLevel().getDescription())
+                .passStatus(applicant.getPassStatus())
+                .classLevel(applicant.getClassLevel() == null ? null : applicant.getClassLevel().getDescription())
                 .createdAt(applicant.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantPassResponseDto.java
+++ b/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantPassResponseDto.java
@@ -1,6 +1,8 @@
 package com.solutio.api.domain.applicant.dto.response;
 
 import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
+import com.solutio.api.domain.member.domain.ClassLevel;
 import com.solutio.api.domain.recruitment.domain.Recruitment;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,18 +17,19 @@ public class ApplicantPassResponseDto {
     private String groupAccountNumber;
     private Long recruitmentId;
     private String passedMessage;
-    private Boolean isPassed;
+    private PassStatus passStatus;
 
     public static ApplicantPassResponseDto from(Applicant applicant, String groupAccountLink, String groupAccountNumber) {
         Recruitment recruitment = applicant.getRecruitment();
+        boolean isApproved = applicant.isApproved();
         return ApplicantPassResponseDto.builder()
             .name(applicant.getName())
-            .classLevel((applicant.getClassLevel() != null) ? applicant.getClassLevel().getDescription() : "미정")
+            .classLevel((applicant.getClassLevel() != null) ? applicant.getClassLevel().getDescription() : ClassLevel.UNASSIGNED.getDescription())
             .recruitmentId(recruitment.getId())
-            .groupAccountLink(applicant.getIsApprove() ? groupAccountLink : null)
-            .groupAccountNumber(applicant.getIsApprove() ? groupAccountNumber : null)
-            .passedMessage(applicant.getIsApprove() ? recruitment.getPassedMessage() : null)
-            .isPassed(applicant.getIsApprove())
+            .groupAccountLink(isApproved ? groupAccountLink : null)
+            .groupAccountNumber(isApproved ? groupAccountNumber : null)
+            .passedMessage(isApproved ? recruitment.getPassedMessage() : null)
+            .passStatus(applicant.getPassStatus())
             .build();
     }
 }

--- a/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantResponseDto.java
+++ b/src/main/java/com/solutio/api/domain/applicant/dto/response/ApplicantResponseDto.java
@@ -1,6 +1,7 @@
 package com.solutio.api.domain.applicant.dto.response;
 
 import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +14,7 @@ public class ApplicantResponseDto {
     private final String name;
     private final String department;
     private final String phoneNumber;
-    private final Boolean isApprove;
+    private final PassStatus passStatus;
     private final String classLevel;
     private final LocalDateTime createdAt;
 
@@ -23,8 +24,8 @@ public class ApplicantResponseDto {
                 .name(applicant.getName())
                 .department(applicant.getDepartment())
                 .phoneNumber(applicant.getPhoneNumber())
-                .isApprove(applicant.getIsApprove())
-                .classLevel(applicant.getClassLevel() == null ? null: applicant.getClassLevel().getDescription())
+                .passStatus(applicant.getPassStatus())
+                .classLevel(applicant.getClassLevel() == null ? null : applicant.getClassLevel().getDescription())
                 .createdAt(applicant.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/solutio/api/domain/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/solutio/api/domain/applicant/repository/ApplicantRepository.java
@@ -1,6 +1,7 @@
 package com.solutio.api.domain.applicant.repository;
 
 import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ApplicantRepository extends JpaRepository<Applicant, String> {
-    List<Applicant> findByRecruitmentIdAndIsApprove(Long id, Boolean isApprove);
+    List<Applicant> findByRecruitmentIdAndPassStatus(Long recruitmentId, PassStatus passStatus);
 
     Page<Applicant> findAllByRecruitmentId(Long recruitmentId, Pageable pageable);
 }

--- a/src/main/java/com/solutio/api/domain/applicant/service/ApplicantService.java
+++ b/src/main/java/com/solutio/api/domain/applicant/service/ApplicantService.java
@@ -1,6 +1,7 @@
 package com.solutio.api.domain.applicant.service;
 
 import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
 import com.solutio.api.domain.applicant.dto.request.ApplicantCreateUpdateRequestDto;
 import com.solutio.api.domain.applicant.dto.request.ApplicantUpdateClassLevelRequestDto;
 import com.solutio.api.domain.applicant.dto.response.ApplicantResponseDto;
@@ -64,7 +65,7 @@ public class ApplicantService {
 
     @Transactional
     public List<String> createMembersByRecruitment(Long recruitmentId) {
-        List<Applicant> applicants = applicantRepository.findByRecruitmentIdAndIsApprove(recruitmentId, true);
+        List<Applicant> applicants = applicantRepository.findByRecruitmentIdAndPassStatus(recruitmentId, PassStatus.APPROVED);
 
         return applicants.stream()
                 .map(this::createMemberFromApplicant)
@@ -76,7 +77,7 @@ public class ApplicantService {
         Applicant applicant = applicantRepository.findById(studentId)
                 .orElseThrow(() -> new GeneralException(Status.APPLICANT_NOT_FOUND));
 
-        if (!applicant.getIsApprove()) {
+        if (!applicant.isApproved()) {
             throw new GeneralException(Status.NOT_APPROVED_APPLICANT);
         }
 
@@ -84,6 +85,9 @@ public class ApplicantService {
     }
 
     private String createMemberFromApplicant(Applicant applicant) {
+        if (!applicant.isApproved()) {
+            throw new GeneralException(Status.NOT_APPROVED_APPLICANT);
+        }
         Member member = memberService.createMember(applicant);
         return member.getStudentId();
     }

--- a/src/main/java/com/solutio/api/domain/member/domain/ClassLevel.java
+++ b/src/main/java/com/solutio/api/domain/member/domain/ClassLevel.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ClassLevel {
+    UNASSIGNED("UNASSIGNED", "미배정"),
     SEED("SEED","Seed"),
     BRANCH("BRANCH", "Branch"),
     TREE("TREE", "Tree"),

--- a/src/test/java/com/solutio/api/ApiApplicationTests.java
+++ b/src/test/java/com/solutio/api/ApiApplicationTests.java
@@ -1,0 +1,17 @@
+package com.solutio.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ApiApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}
+
+

--- a/src/test/java/com/solutio/api/domain/applicant/domain/ApplicantTest.java
+++ b/src/test/java/com/solutio/api/domain/applicant/domain/ApplicantTest.java
@@ -1,0 +1,96 @@
+package com.solutio.api.domain.applicant.domain;
+
+import com.solutio.api.domain.applicant.dto.request.ApplicantUpdateClassLevelRequestDto;
+import com.solutio.api.domain.member.domain.ClassLevel;
+import com.solutio.api.domain.member.domain.MainLanguage;
+import com.solutio.api.domain.recruitment.domain.Recruitment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicantTest {
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    private Applicant createDefaultApplicant() {
+        Recruitment recruitment = Recruitment.create(
+                "2026 1학기 신입부원 모집",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(7)
+        );
+
+        return Applicant.create(
+                "202600001",
+                recruitment,
+                "test@kyonggi.ac.kr",
+                "password123!",
+                "컴퓨터공학부",
+                "홍길동",
+                "010-1234-5678",
+                "boj_hong",
+                MainLanguage.JAVA,
+                "지원 동기입니다.",
+                passwordEncoder
+        );
+    }
+
+    @Test
+    @DisplayName("신규 Applicant 생성 시 passStatus는 PENDING, classLevel은 UNASSIGNED이다")
+    void create_defaultValues_arePendingAndUnassigned() {
+        Applicant applicant = createDefaultApplicant();
+
+        assertThat(applicant.getPassStatus()).isEqualTo(PassStatus.PENDING);
+        assertThat(applicant.getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+    }
+
+    @Test
+    @DisplayName("approve() 호출 시 passStatus가 APPROVED로 변경된다")
+    void approve_changesPassStatusToApproved() {
+        Applicant applicant = createDefaultApplicant();
+
+        applicant.approve();
+
+        assertThat(applicant.getPassStatus()).isEqualTo(PassStatus.APPROVED);
+        assertThat(applicant.isApproved()).isTrue();
+    }
+
+    @Test
+    @DisplayName("reject() 호출 시 passStatus가 REJECTED로 변경된다")
+    void reject_changesPassStatusToRejected() {
+        Applicant applicant = createDefaultApplicant();
+
+        applicant.reject();
+
+        assertThat(applicant.getPassStatus()).isEqualTo(PassStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("updateClassLevel() 호출 시 classLevel이 전달받은 값으로 변경된다")
+    void updateClassLevel_updatesClassLevel() {
+        Applicant applicant = createDefaultApplicant();
+        ApplicantUpdateClassLevelRequestDto requestDto = new ApplicantUpdateClassLevelRequestDto();
+        ReflectionTestUtils.setField(requestDto, "classLevel", ClassLevel.SEED);
+
+        applicant.updateClassLevel(requestDto);
+
+        assertThat(applicant.getClassLevel()).isEqualTo(ClassLevel.SEED);
+    }
+
+    @Test
+    @DisplayName("updateClassLevel() 호출 시 null이 전달되면 UNASSIGNED로 설정된다")
+    void updateClassLevel_null_setsUnassigned() {
+        Applicant applicant = createDefaultApplicant();
+        ApplicantUpdateClassLevelRequestDto requestDto = new ApplicantUpdateClassLevelRequestDto();
+        ReflectionTestUtils.setField(requestDto, "classLevel", null);
+
+        applicant.updateClassLevel(requestDto);
+
+        assertThat(applicant.getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+    }
+}

--- a/src/test/java/com/solutio/api/domain/applicant/integration/ApplicantControllerIntegrationTest.java
+++ b/src/test/java/com/solutio/api/domain/applicant/integration/ApplicantControllerIntegrationTest.java
@@ -1,0 +1,213 @@
+package com.solutio.api.domain.applicant.integration;
+
+import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
+import com.solutio.api.domain.applicant.repository.ApplicantRepository;
+import com.solutio.api.domain.member.domain.ClassLevel;
+import com.solutio.api.domain.member.domain.MainLanguage;
+import com.solutio.api.domain.member.repository.MemberRepository;
+import com.solutio.api.domain.recruitment.domain.Recruitment;
+import com.solutio.api.domain.recruitment.domain.RecruitmentStatus;
+import com.solutio.api.domain.recruitment.repository.RecruitmentRepository;
+import com.solutio.api.global.auth.jwt.TokenProvider;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ApplicantControllerIntegrationTest {
+
+    @Autowired
+    MockMvcTester mvcTester;
+
+    @Autowired
+    TokenProvider tokenProvider;
+
+    @Autowired
+    ApplicantRepository applicantRepository;
+
+    @Autowired
+    RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    EntityManager em;
+
+    static final String STUDENT_ID = "202612345";
+
+    private String generateToken(String studentId, String role) {
+        return tokenProvider.generateToken(studentId, Duration.ofHours(1), role);
+    }
+
+    private Recruitment createRecruitment() {
+        Recruitment recruitment = Recruitment.create(
+                "2026 신입 모집",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(7)
+        );
+        ReflectionTestUtils.setField(recruitment, "status", RecruitmentStatus.OPEN);
+        return recruitmentRepository.save(recruitment);
+    }
+
+    private Applicant createApplicant(Recruitment recruitment) {
+        return applicantRepository.save(Applicant.create(
+                STUDENT_ID,
+                recruitment,
+                STUDENT_ID + "@kyonggi.ac.kr",
+                "password123!",
+                "컴퓨터공학부",
+                "홍길동",
+                "010-1234-5678",
+                STUDENT_ID + "_boj",
+                MainLanguage.JAVA,
+                "지원동기입니다",
+                new BCryptPasswordEncoder()
+        ));
+    }
+
+    @Test
+    @DisplayName("신규 지원 시 passStatus는 PENDING, classLevel은 UNASSIGNED로 저장된다")
+    void applyForClub_savesDefaultPassStatusAndClassLevel() {
+        Recruitment recruitment = createRecruitment();
+
+        var result = assertThat(mvcTester.post().uri("/api/v1/applicants")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                            "studentId": "202699999",
+                            "recruitmentId": %d,
+                            "email": "newapp@kyonggi.ac.kr",
+                            "password": "password123!",
+                            "department": "컴퓨터공학부",
+                            "name": "신규지원",
+                            "phoneNumber": "010-9999-8888",
+                            "bojId": "new_boj",
+                            "mainLanguage": "JAVA",
+                            "applyReason": "신청합니다"
+                        }
+                        """.formatted(recruitment.getId())));
+
+        result.hasStatus2xxSuccessful();
+
+        Applicant applicant = applicantRepository.findById("202699999").orElseThrow();
+        assertThat(applicant.getPassStatus()).isEqualTo(PassStatus.PENDING);
+        assertThat(applicant.getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+    }
+
+    @Test
+    @DisplayName("STAFF 권한으로 지원자 합격 처리 시 passStatus가 APPROVED로 업데이트된다")
+    void approveApplicant_asStaff_updatesPassStatusToApproved() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = createApplicant(recruitment);
+
+        String staffToken = generateToken("202000001", "STAFF");
+
+        var result = assertThat(mvcTester.patch().uri("/api/v1/applicants/approve/" + applicant.getStudentId())
+                .header("Authorization", "Bearer " + staffToken));
+
+        result.hasStatus2xxSuccessful();
+
+        em.flush();
+        em.clear();
+
+        Applicant updated = applicantRepository.findById(applicant.getStudentId()).orElseThrow();
+        assertThat(updated.getPassStatus()).isEqualTo(PassStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("STAFF 권한으로 지원자 불합격 처리 시 passStatus가 REJECTED로 업데이트된다")
+    void rejectApplicant_asStaff_updatesPassStatusToRejected() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = createApplicant(recruitment);
+
+        String staffToken = generateToken("202000001", "STAFF");
+
+        var result = assertThat(mvcTester.patch().uri("/api/v1/applicants/reject/" + applicant.getStudentId())
+                .header("Authorization", "Bearer " + staffToken));
+
+        result.hasStatus2xxSuccessful();
+
+        em.flush();
+        em.clear();
+
+        Applicant updated = applicantRepository.findById(applicant.getStudentId()).orElseThrow();
+        assertThat(updated.getPassStatus()).isEqualTo(PassStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태의 신청자는 개별 회원 전환 시 409 CONFLICT를 반환한다")
+    void registerMember_pendingStatus_returns409() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = createApplicant(recruitment);
+
+        String nestToken = generateToken("202000001", "NEST");
+
+        var result = assertThat(mvcTester.post().uri("/api/v1/applicants/" + applicant.getStudentId())
+                .header("Authorization", "Bearer " + nestToken));
+
+        result.hasStatus(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("APPROVED 상태의 신청자만 개별 회원 전환이 성공한다")
+    void registerMember_approvedStatus_succeeds() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = createApplicant(recruitment);
+        applicant.approve();
+        applicantRepository.save(applicant);
+
+        String nestToken = generateToken("202000001", "NEST");
+
+        var result = assertThat(mvcTester.post().uri("/api/v1/applicants/" + applicant.getStudentId())
+                .header("Authorization", "Bearer " + nestToken));
+
+        result.hasStatus2xxSuccessful();
+        assertThat(memberRepository.findById(applicant.getStudentId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("합격 여부 조회 시 passStatus를 포함한 DTO를 반환한다")
+    void checkApplicantPass_returnsPassStatus() {
+        Recruitment recruitment = Recruitment.create(
+                "2026 종료된 모집",
+                LocalDateTime.now().minusDays(7),
+                LocalDateTime.now().minusDays(1)
+        );
+        ReflectionTestUtils.setField(recruitment, "status", RecruitmentStatus.CLOSED);
+        recruitmentRepository.save(recruitment);
+
+        Applicant applicant = createApplicant(recruitment);
+        applicant.approve();
+        applicantRepository.save(applicant);
+
+        String guestToken = generateToken(applicant.getStudentId(), "GUEST");
+
+        var result = assertThat(mvcTester.get().uri("/api/v1/applicants/my")
+                .header("Authorization", "Bearer " + guestToken)
+                .accept(MediaType.APPLICATION_JSON));
+
+        result.hasStatus2xxSuccessful()
+                .bodyJson().extractingPath("$.data.passStatus").isEqualTo("APPROVED");
+        result.bodyJson().extractingPath("$.data.classLevel").isEqualTo("미배정");
+    }
+}

--- a/src/test/java/com/solutio/api/domain/applicant/repository/ApplicantRepositoryTest.java
+++ b/src/test/java/com/solutio/api/domain/applicant/repository/ApplicantRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.solutio.api.domain.applicant.repository;
+
+import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
+import com.solutio.api.domain.member.domain.ClassLevel;
+import com.solutio.api.domain.member.domain.MainLanguage;
+import com.solutio.api.domain.recruitment.domain.Recruitment;
+import com.solutio.api.domain.recruitment.repository.RecruitmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class ApplicantRepositoryTest {
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @Test
+    @DisplayName("findByRecruitmentIdAndPassStatus는 해당 Recruitment와 PassStatus에 해당하는 지원자를 조회한다")
+    void findByRecruitmentIdAndPassStatus_returnsMatchingApplicants() {
+        Recruitment recruitment = recruitmentRepository.save(Recruitment.create(
+                "2026 1학기 recruitment",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(7)
+        ));
+
+        Applicant applicant1 = Applicant.create(
+                "202600001", recruitment, "app1@kyonggi.ac.kr", "pass", "학과", "김지원",
+                "010-1111-2222", "boj1", MainLanguage.JAVA, "이유1", passwordEncoder
+        );
+        Applicant applicant2 = Applicant.create(
+                "202600002", recruitment, "app2@kyonggi.ac.kr", "pass", "학과", "이지원",
+                "010-3333-4444", "boj2", MainLanguage.PYTHON, "이유2", passwordEncoder
+        );
+
+        applicant1.approve();
+        applicantRepository.save(applicant1);
+        applicantRepository.save(applicant2);
+
+        List<Applicant> approvedList = applicantRepository.findByRecruitmentIdAndPassStatus(recruitment.getId(), PassStatus.APPROVED);
+        List<Applicant> pendingList = applicantRepository.findByRecruitmentIdAndPassStatus(recruitment.getId(), PassStatus.PENDING);
+        List<Applicant> rejectedList = applicantRepository.findByRecruitmentIdAndPassStatus(recruitment.getId(), PassStatus.REJECTED);
+
+        assertThat(approvedList).hasSize(1);
+        assertThat(approvedList.get(0).getStudentId()).isEqualTo("202600001");
+        assertThat(approvedList.get(0).getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+
+        assertThat(pendingList).hasSize(1);
+        assertThat(pendingList.get(0).getStudentId()).isEqualTo("202600002");
+
+        assertThat(rejectedList).isEmpty();
+    }
+}

--- a/src/test/java/com/solutio/api/domain/applicant/service/ApplicantServiceTest.java
+++ b/src/test/java/com/solutio/api/domain/applicant/service/ApplicantServiceTest.java
@@ -1,0 +1,231 @@
+package com.solutio.api.domain.applicant.service;
+
+import com.solutio.api.domain.applicant.domain.Applicant;
+import com.solutio.api.domain.applicant.domain.PassStatus;
+import com.solutio.api.domain.applicant.dto.request.ApplicantCreateUpdateRequestDto;
+import com.solutio.api.domain.applicant.dto.response.ApplicantDetailResponseDto;
+import com.solutio.api.domain.applicant.dto.response.ApplicantResponseDto;
+import com.solutio.api.domain.applicant.repository.ApplicantRepository;
+import com.solutio.api.domain.member.domain.ClassLevel;
+import com.solutio.api.domain.member.domain.MainLanguage;
+import com.solutio.api.domain.member.domain.Member;
+import com.solutio.api.domain.member.repository.MemberRepository;
+import com.solutio.api.domain.member.service.MemberService;
+import com.solutio.api.domain.recruitment.domain.Recruitment;
+import com.solutio.api.domain.recruitment.domain.RecruitmentStatus;
+import com.solutio.api.domain.recruitment.repository.RecruitmentRepository;
+import com.solutio.api.domain.recruitment.service.RecruitmentService;
+import com.solutio.api.global.response.GeneralException;
+import com.solutio.api.global.response.PageResponse;
+import com.solutio.api.global.response.Status;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import({ApplicantService.class, MemberService.class, RecruitmentService.class, BCryptPasswordEncoder.class})
+@Transactional
+class ApplicantServiceTest {
+
+    @Autowired
+    private ApplicantService applicantService;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Recruitment createRecruitment() {
+        Recruitment recruitment = Recruitment.create(
+                "2026 Recruitment",
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(7)
+        );
+        ReflectionTestUtils.setField(recruitment, "status", RecruitmentStatus.OPEN);
+        return recruitmentRepository.save(recruitment);
+    }
+
+    @Test
+    @DisplayName("신청 시 기본 passStatus는 PENDING, classLevel은 UNASSIGNED이다")
+    void applyMember_createsApplicantWithPendingAndUnassigned() {
+        Recruitment recruitment = createRecruitment();
+
+        ApplicantCreateUpdateRequestDto requestDto = new ApplicantCreateUpdateRequestDto();
+        ReflectionTestUtils.setField(requestDto, "studentId", "202600001");
+        ReflectionTestUtils.setField(requestDto, "recruitmentId", recruitment.getId());
+        ReflectionTestUtils.setField(requestDto, "email", "test@kyonggi.ac.kr");
+        ReflectionTestUtils.setField(requestDto, "password", "password123!");
+        ReflectionTestUtils.setField(requestDto, "department", "컴퓨터공학부");
+        ReflectionTestUtils.setField(requestDto, "name", "홍길동");
+        ReflectionTestUtils.setField(requestDto, "phoneNumber", "010-1234-5678");
+        ReflectionTestUtils.setField(requestDto, "bojId", "boj_hong");
+        ReflectionTestUtils.setField(requestDto, "mainLanguage", MainLanguage.JAVA);
+        ReflectionTestUtils.setField(requestDto, "applyReason", "지원동기");
+
+        String studentId = applicantService.applyMember(requestDto);
+
+        em.flush();
+        em.clear();
+
+        Applicant applicant = applicantRepository.findById(studentId).orElseThrow();
+        assertThat(applicant.getPassStatus()).isEqualTo(PassStatus.PENDING);
+        assertThat(applicant.getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+    }
+
+    @Test
+    @DisplayName("approveApplicant는 지원자의 passStatus를 APPROVED로 변경한다")
+    void approveApplicant_changesStatusToApproved() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+
+        applicantService.approveApplicant(applicant.getStudentId());
+
+        em.flush();
+        em.clear();
+
+        Applicant updated = applicantRepository.findById(applicant.getStudentId()).orElseThrow();
+        assertThat(updated.getPassStatus()).isEqualTo(PassStatus.APPROVED);
+    }
+
+    @Test
+    @DisplayName("rejectApplicant는 지원자의 passStatus를 REJECTED로 변경한다")
+    void rejectApplicant_changesStatusToRejected() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+
+        applicantService.rejectApplicant(applicant.getStudentId());
+
+        em.flush();
+        em.clear();
+
+        Applicant updated = applicantRepository.findById(applicant.getStudentId()).orElseThrow();
+        assertThat(updated.getPassStatus()).isEqualTo(PassStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("passStatus가 PENDING인 경우 Member 생성 시 예외가 발생한다")
+    void createMemberByRecruitment_pendingStatus_throwsException() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+
+        assertThatThrownBy(() -> applicantService.createMemberByRecruitment(applicant.getStudentId()))
+                .isInstanceOf(GeneralException.class)
+                .extracting("status")
+                .isEqualTo(Status.NOT_APPROVED_APPLICANT);
+    }
+
+    @Test
+    @DisplayName("passStatus가 REJECTED인 경우 Member 생성 시 예외가 발생한다")
+    void createMemberByRecruitment_rejectedStatus_throwsException() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+        applicant.reject();
+        applicantRepository.save(applicant);
+
+        assertThatThrownBy(() -> applicantService.createMemberByRecruitment(applicant.getStudentId()))
+                .isInstanceOf(GeneralException.class)
+                .extracting("status")
+                .isEqualTo(Status.NOT_APPROVED_APPLICANT);
+    }
+
+    @Test
+    @DisplayName("passStatus가 APPROVED인 지원자만 Member 생성이 가능하다")
+    void createMemberByRecruitment_approvedStatus_createsMember() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+        applicant.approve();
+        applicantRepository.save(applicant);
+
+        String createdId = applicantService.createMemberByRecruitment(applicant.getStudentId());
+
+        assertThat(createdId).isEqualTo("202600001");
+        Member member = memberRepository.findById("202600001").orElseThrow();
+        assertThat(member.getClassLevel()).isEqualTo(ClassLevel.UNASSIGNED);
+    }
+
+    @Test
+    @DisplayName("createMembersByRecruitment는 APPROVED 상태의 지원자 목록만 Member로 전환한다")
+    void createMembersByRecruitment_convertsOnlyApprovedApplicants() {
+        Recruitment recruitment = createRecruitment();
+
+        Applicant app1 = Applicant.create(
+                "202600001", recruitment, "app1@kyonggi.ac.kr", "pass", "컴공", "김합격",
+                "010-1111-2222", "boj1", MainLanguage.JAVA, "동기1", new BCryptPasswordEncoder()
+        );
+        Applicant app2 = Applicant.create(
+                "202600002", recruitment, "app2@kyonggi.ac.kr", "pass", "컴공", "이대기",
+                "010-3333-4444", "boj2", MainLanguage.PYTHON, "동기2", new BCryptPasswordEncoder()
+        );
+        Applicant app3 = Applicant.create(
+                "202600003", recruitment, "app3@kyonggi.ac.kr", "pass", "컴공", "박불합",
+                "010-5555-6666", "boj3", MainLanguage.C, "동기3", new BCryptPasswordEncoder()
+        );
+
+        app1.approve();
+        app3.reject();
+
+        applicantRepository.save(app1);
+        applicantRepository.save(app2);
+        applicantRepository.save(app3);
+
+        List<String> createdIds = applicantService.createMembersByRecruitment(recruitment.getId());
+
+        assertThat(createdIds).containsExactly("202600001");
+    }
+
+    @Test
+    @DisplayName("ApplicantDetailResponseDto 및 ApplicantResponseDto는 passStatus와 description을 올바르게 반환한다")
+    void getApplicant_and_getApplicants_returnPassStatusAndClassLevelDescription() {
+        Recruitment recruitment = createRecruitment();
+        Applicant applicant = applicantRepository.save(Applicant.create(
+                "202600001", recruitment, "test@kyonggi.ac.kr", "pass", "컴공", "홍길동",
+                "010-1234-5678", "boj_hong", MainLanguage.JAVA, "동기", new BCryptPasswordEncoder()
+        ));
+
+        ApplicantDetailResponseDto detailDto = applicantService.getApplicant(applicant.getStudentId());
+        assertThat(detailDto.getPassStatus()).isEqualTo(PassStatus.PENDING);
+        assertThat(detailDto.getClassLevel()).isEqualTo("미배정");
+
+        PageResponse<ApplicantResponseDto> pageResponse = applicantService.getApplicants(recruitment.getId(), PageRequest.of(0, 10));
+        assertThat(pageResponse.getContents()).hasSize(1);
+        assertThat(pageResponse.getContents().get(0).getPassStatus()).isEqualTo(PassStatus.PENDING);
+        assertThat(pageResponse.getContents().get(0).getClassLevel()).isEqualTo("미배정");
+    }
+}


### PR DESCRIPTION
## 요약

- Close #50 
- PassStatus Enum을 추가하고, ClassLevel Enum에 상태를 추가하였습니다.

## 변경 사항

 - `PassStatus` Enum 생성 및 `ClassLevel` Enum에 `UNASSIGNED("미배정")` 추가
  - `Applicant` 엔티티 `isApprove` 필드를 `passStatus`로 교체 및 팩토리 메서드 기본값 설정 (`PENDING`,
`UNASSIGNED`)
  - `Applicant` 도메인 메서드(`approve()`, `reject()`, `isApproved()`, `updateClassLevel()`) 수정
  - `ApplicantRepository` 쿼리 메서드(`findByRecruitmentIdAndPassStatus`) 수정
  - `ApplicantService` 회원 전환 시 `APPROVED` 상태 검증 로직 강화
  - DTO 필드 및 응답 구조 수정 (`ApplicantResponseDto`, `ApplicantDetailResponseDto`,
`ApplicantPassResponseDto`)
  - 관련 단위 및 통합 테스트 코드 추가 및 업데이트